### PR TITLE
read child-dirs without any outside aids

### DIFF
--- a/child-dirs/nude/index.js
+++ b/child-dirs/nude/index.js
@@ -1,0 +1,24 @@
+var fs = require('fs')
+
+function readDirs(dir, cb) {
+  fs.readdir(dir, function (err, dir) {
+    if(err) return cb(err)
+    var n = 0, dirs = []
+    dir.forEach(function (d) {
+      n++
+      fs.stat(d, function (err, stat) {
+        if(err) return cb(err)
+        if(stat.isDirectory()) dirs.push(d)
+        next()
+      })
+    })
+    function next () {
+      if(--n) return
+      cb(null, dirs)
+    }
+    if(!n) next()
+  })
+}
+
+if(!module.parent)
+  readDirs(process.cwd(), console.log)

--- a/child-dirs/nude/index.js
+++ b/child-dirs/nude/index.js
@@ -1,10 +1,10 @@
 var fs = require('fs')
 
 function readDirs(dir, cb) {
-  fs.readdir(dir, function (err, dir) {
+  fs.readdir(dir, function (err, ls) {
     if(err) return cb(err)
     var n = 0, dirs = []
-    dir.forEach(function (d) {
+    ls.forEach(function (d) {
       n++
       fs.stat(d, function (err, stat) {
         if(err) return cb(err)


### PR DESCRIPTION
to be fair,
we should compare using the various callback managing libs with using no libs at all,
thus, here is the example implemented "nude".

Interestingly, it's by no means the longest example...
